### PR TITLE
fix(csv): [LSPD-5698] Add option to insert UTF8 BOM

### DIFF
--- a/ninio-csv/src/main/java/com/davfx/ninio/csv/CsvWrite.java
+++ b/ninio-csv/src/main/java/com/davfx/ninio/csv/CsvWrite.java
@@ -1,5 +1,9 @@
 package com.davfx.ninio.csv;
 
+import com.davfx.ninio.csv.dependencies.Dependencies;
+import com.davfx.ninio.util.ConfigUtils;
+import com.typesafe.config.Config;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -7,21 +11,21 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
-
-import com.davfx.ninio.csv.dependencies.Dependencies;
-import com.davfx.ninio.util.ConfigUtils;
-import com.typesafe.config.Config;
+import java.nio.charset.StandardCharsets;
 
 public final class CsvWrite {
-	
+
+	private static final String UTF8_BOM = "\uFEFF";
 	private static final Config CONFIG = ConfigUtils.load(new Dependencies()).getConfig(CsvWrite.class.getPackage().getName());
 	private static final Charset DEFAULT_CHARSET = Charset.forName(CONFIG.getString("charset"));
 	private static final char DEFAULT_DELIMITER = ConfigUtils.getChar(CONFIG, "delimiter");
 	private static final char DEFAULT_QUOTE = ConfigUtils.getChar(CONFIG, "quote");
+	private static final boolean DEFAULT_ENFORCE_UTF8_BOM = CONFIG.getBoolean("enforceUtf8Bom");
 
 	private Charset charset = DEFAULT_CHARSET;
 	private char delimiter = DEFAULT_DELIMITER;
 	private char quote = DEFAULT_QUOTE;
+	private boolean enforceUtf8Bom = DEFAULT_ENFORCE_UTF8_BOM;
 	
 	public CsvWrite() {
 	}
@@ -38,9 +42,14 @@ public final class CsvWrite {
 		this.charset = charset;
 		return this;
 	}
+	public CsvWrite enforceUtf8Bom(boolean enforce) {
+		this.enforceUtf8Bom = enforce;
+		return this;
+	}
 
 	public MayAutoCloseCsvWriter to(final OutputStream out)  {
-		final CsvWriter csvWriter = new CsvWriterImpl(charset, delimiter, quote, out);
+		final OutputStream prefixedOutputStream = outputStream(out);
+		final CsvWriter csvWriter = new CsvWriterImpl(charset, delimiter, quote, prefixedOutputStream);
 		return new MayAutoCloseCsvWriter() {
 			@Override
 			public Line line() throws IOException {
@@ -85,6 +94,12 @@ public final class CsvWrite {
 	public AutoCloseableCsvWriter append(File file) throws IOException {
 		return to(new FileOutputStream(file, true)).autoClose();
 	}
+
+	private OutputStream outputStream(OutputStream out) {
+		return (charset.equals(StandardCharsets.UTF_8) && enforceUtf8Bom)
+				? new PrefixedOutputStream(out, UTF8_BOM)
+				: out;
+	}
 	
 	private static final class CsvWriterImpl implements CsvWriter {
 		private static String encode(char quote, String s) {
@@ -96,7 +111,7 @@ public final class CsvWrite {
 			private final char quote;
 			private final Writer writer;
 			private boolean beginning = true;
-			
+
 			public InnerLine(char delimiter, char quote, Writer writer) {
 				this.writer = writer;
 				this.delimiter = delimiter;
@@ -137,7 +152,7 @@ public final class CsvWrite {
 		public CsvWriterImpl(Charset charset, char delimiter, char quote, OutputStream out) {
 			this.delimiter = delimiter;
 			this.quote = quote;
-			writer = new OutputStreamWriter(out, charset);
+			this.writer = new OutputStreamWriter(out, charset);
 		}
 
 		@Override
@@ -148,6 +163,51 @@ public final class CsvWrite {
 		@Override
 		public void flush() throws IOException {
 			writer.flush();
+		}
+	}
+
+	private static class PrefixedOutputStream extends OutputStream {
+
+		private boolean firstWrite = true;
+		private final OutputStream out;
+		private final String prefix;
+
+		public PrefixedOutputStream(OutputStream out, String prefix) {
+			this.out = out;
+			this.prefix = prefix;
+		}
+
+		@Override
+		public void write(int b) throws IOException {
+			prefixOnFirstWrite();
+			out.write(b);
+		}
+		@Override
+		public void write(byte[] b) throws IOException {
+			prefixOnFirstWrite();
+			out.write(b);
+		}
+		@Override
+		public void write(byte[] b, int off, int len) throws IOException {
+			prefixOnFirstWrite();
+			out.write(b, off, len);
+		}
+
+		private void prefixOnFirstWrite() throws IOException {
+			if (!firstWrite) {
+				return;
+			}
+			firstWrite = false;
+			out.write(prefix.getBytes());
+		}
+
+		@Override
+		public void flush() throws IOException {
+			out.flush();
+		}
+		@Override
+		public void close() throws IOException {
+			out.close();
 		}
 	}
 }

--- a/ninio-csv/src/main/resources/com.davfx.ninio.csv.conf
+++ b/ninio-csv/src/main/resources/com.davfx.ninio.csv.conf
@@ -2,6 +2,7 @@ com.davfx.ninio.csv {
 	charset = "UTF-8"
 	delimiter = ","
 	quote = "\""
+	enforceUtf8Bom = false
 	ignoreEmptyLines = true
 	invalid = [] // May be [ "\n" ]
 }


### PR DESCRIPTION
Add an option to insert UTF-8 BOM character (0xEF, 0xBB, 0xBF) to utf-8 file for compat with Excel.
[Wiki](https://en.wikipedia.org/wiki/Byte_order_mark#:~:text=These%20tools%20add%20a%20BOM%20when%20saving%20text%20as%20UTF%2D8%2C%20and%20cannot%20interpret%20UTF%2D8%20unless%20the%20BOM%20is%20present%20or%20the%20file%20contains%20only%20ASCII): 

> These tools add a BOM when saving text as UTF-8, and cannot interpret UTF-8 unless the BOM is present or the file contains only ASCII