### PR TITLE
feat: [LSPD-5734] ProxyClient now add recipientId in connection command headers

### DIFF
--- a/ninio-proxy/src/main/java/com/davfx/ninio/proxy/ProxyHeader.java
+++ b/ninio-proxy/src/main/java/com/davfx/ninio/proxy/ProxyHeader.java
@@ -1,15 +1,16 @@
 package com.davfx.ninio.proxy;
 
-import java.util.List;
-import java.util.Map;
-
 import com.davfx.ninio.util.StringUtils;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 
+import java.util.List;
+import java.util.Map;
+
 public final class ProxyHeader {
 	public final String type;
 	public final ImmutableMap<String, String> parameters;
+
 	public ProxyHeader(String type, ImmutableMap<String, String> parameters) {
 		this.type = type;
 		this.parameters = parameters;
@@ -18,7 +19,15 @@ public final class ProxyHeader {
 		this.type = type;
 		parameters = ImmutableMap.of();
 	}
-	
+
+	public ProxyHeader withParameter(String name, String value) {
+		ImmutableMap<String, String> newParameters = ImmutableMap.<String, String>builder()
+				.putAll(parameters)
+				.put(name, value)
+				.build();
+		return new ProxyHeader(type, newParameters);
+	}
+
 	@Override
 	public String toString() {
 		StringBuilder b = new StringBuilder(StringUtils.escape(type, ' '));

--- a/ninio-proxy/src/main/java/com/davfx/ninio/proxy/ProxyProvider.java
+++ b/ninio-proxy/src/main/java/com/davfx/ninio/proxy/ProxyProvider.java
@@ -3,6 +3,6 @@ package com.davfx.ninio.proxy;
 import com.davfx.ninio.core.*;
 
 public interface ProxyProvider extends Disconnectable {
-	RawSocket.Builder raw();
-	WithHeaderSocketBuilder factory();
+	RawSocket.Builder raw(String recipientId);
+	WithHeaderSocketBuilder factory(String recipientId);
 }

--- a/ninio-proxy/src/test/java/com/davfx/ninio/proxy/EchoTest.java
+++ b/ninio-proxy/src/test/java/com/davfx/ninio/proxy/EchoTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import static com.davfx.ninio.proxy.TestUtil.DEFAULT_RECIPIENT_ID;
 import static com.davfx.ninio.proxy.TestUtil.findAvailablePort;
 
 public class EchoTest {
@@ -45,7 +46,7 @@ public class EchoTest {
 				}
 				@Override
 				public NinioBuilder<Connecter> create(Address address, String header) {
-					if (header.equals("_")) {
+					if (header.startsWith("_")) {
 						return new EchoNinioSocketBuilder();
 					} else {
 						return null;
@@ -60,7 +61,7 @@ public class EchoTest {
 					final Wait clientWaitClientConnecting = new Wait();
 					final Wait clientWaitClientClosing = new Wait();
 
-					try (Connecter client = ninio.create(proxyClient.factory().header(new ProxyHeader("_")).with(new Address(Address.LOCALHOST, port)))) {
+					try (Connecter client = ninio.create(proxyClient.factory(DEFAULT_RECIPIENT_ID).header(new ProxyHeader("_")).with(new Address(Address.LOCALHOST, port)))) {
 						client.connect(new Connection() {
 							
 							@Override
@@ -100,11 +101,10 @@ public class EchoTest {
 	public void testSameToCheckClose() throws Exception {
 		test();
 	}
-	
+
 	@Test
 	public void testTwice() throws Exception {
 		final Lock<ByteBuffer, IOException> lock = new Lock<>();
-		
 		try (Ninio ninio = Ninio.create()) {
 			int proxyPort = findAvailablePort();
 
@@ -125,7 +125,7 @@ public class EchoTest {
 				}
 				@Override
 				public NinioBuilder<Connecter> create(Address address, String header) {
-					if (header.equals("_")) {
+					if (header.startsWith("_")) {
 						return new EchoNinioSocketBuilder();
 					} else {
 						return null;
@@ -141,7 +141,7 @@ public class EchoTest {
 						final Wait clientWaitClientConnecting = new Wait();
 						final Wait clientWaitClientClosing = new Wait();
 
-						try (Connecter client = ninio.create(proxyClient.factory().header(new ProxyHeader("_")).with(new Address(Address.LOCALHOST, port)))) {
+						try (Connecter client = ninio.create(proxyClient.factory(DEFAULT_RECIPIENT_ID).header(new ProxyHeader("_")).with(new Address(Address.LOCALHOST, port)))) {
 							client.connect(new Connection() {
 								
 								@Override

--- a/ninio-proxy/src/test/java/com/davfx/ninio/proxy/PingTest.java
+++ b/ninio-proxy/src/test/java/com/davfx/ninio/proxy/PingTest.java
@@ -12,6 +12,8 @@ import com.davfx.ninio.util.Lock;
 
 import java.io.IOException;
 
+import static com.davfx.ninio.proxy.TestUtil.DEFAULT_RECIPIENT_ID;
+
 //mvn install dependency:copy-dependencies
 //sudo java -cp target/dependency/*:target/test-classes/:target/classes/ com.davfx.ninio.proxy.PingTest
 public class PingTest {
@@ -27,7 +29,7 @@ public class PingTest {
 			
 			try (Disconnectable proxyServer = ninio.create(ProxyServer.defaultUnsecureServer(new Address(Address.ANY, proxyPort), null))) {
 				try (ProxyProvider proxyClient = ninio.create(ProxyClient.defaultUnsecureClient(new Address(Address.LOCALHOST, proxyPort)))) {
-					try (PingConnecter client = PingTimeout.wrap(1d, ninio.create(PingClient.builder().with(proxyClient.raw())))) {
+					try (PingConnecter client = PingTimeout.wrap(1d, ninio.create(PingClient.builder().with(proxyClient.raw(DEFAULT_RECIPIENT_ID))))) {
 						client.connect(new PingConnection() {
 							@Override
 							public void failed(IOException ioe) {

--- a/ninio-proxy/src/test/java/com/davfx/ninio/proxy/ProxyOpenCloseOpenPingTest.java
+++ b/ninio-proxy/src/test/java/com/davfx/ninio/proxy/ProxyOpenCloseOpenPingTest.java
@@ -12,6 +12,8 @@ import com.davfx.ninio.util.Lock;
 
 import java.io.IOException;
 
+import static com.davfx.ninio.proxy.TestUtil.DEFAULT_RECIPIENT_ID;
+
 //mvn install dependency:copy-dependencies
 //sudo java -cp target/dependency/*:target/test-classes/:target/classes/ com.davfx.ninio.proxy.PingTest
 public class ProxyOpenCloseOpenPingTest {
@@ -26,7 +28,7 @@ public class ProxyOpenCloseOpenPingTest {
 			try (Disconnectable proxyServer = ninio.create(ProxyServer.defaultUnsecureServer(new Address(Address.ANY, proxyPort), null))) {
 				try (ProxyProvider proxyClient0 = ninio.create(ProxyClient.defaultUnsecureClient(new Address(Address.LOCALHOST, proxyPort)))) {
 					final Lock<Double, IOException> lock0 = new Lock<>();
-					try (PingConnecter client0 = PingTimeout.wrap(1d, ninio.create(PingClient.builder().with(proxyClient0.raw())))) {
+					try (PingConnecter client0 = PingTimeout.wrap(1d, ninio.create(PingClient.builder().with(proxyClient0.raw(DEFAULT_RECIPIENT_ID))))) {
 						client0.connect(new PingConnection() {
 							@Override
 							public void failed(IOException ioe) {
@@ -55,7 +57,7 @@ public class ProxyOpenCloseOpenPingTest {
 				}
 				try (ProxyProvider proxyClient1 = ninio.create(ProxyClient.defaultUnsecureClient(new Address(Address.LOCALHOST, proxyPort)))) {
 					final Lock<Double, IOException> lock1 = new Lock<>();
-					try (PingConnecter client1 = PingTimeout.wrap(1d, ninio.create(PingClient.builder().with(proxyClient1.raw())))) {
+					try (PingConnecter client1 = PingTimeout.wrap(1d, ninio.create(PingClient.builder().with(proxyClient1.raw(DEFAULT_RECIPIENT_ID))))) {
 						client1.connect(new PingConnection() {
 							@Override
 							public void failed(IOException ioe) {

--- a/ninio-proxy/src/test/java/com/davfx/ninio/proxy/ProxyOpenLeaveOpenPingTest.java
+++ b/ninio-proxy/src/test/java/com/davfx/ninio/proxy/ProxyOpenLeaveOpenPingTest.java
@@ -12,6 +12,8 @@ import com.davfx.ninio.util.Lock;
 
 import java.io.IOException;
 
+import static com.davfx.ninio.proxy.TestUtil.DEFAULT_RECIPIENT_ID;
+
 //mvn install dependency:copy-dependencies
 //sudo java -cp target/dependency/*:target/test-classes/:target/classes/ com.davfx.ninio.proxy.PingTest
 public class ProxyOpenLeaveOpenPingTest {
@@ -26,7 +28,7 @@ public class ProxyOpenLeaveOpenPingTest {
 			try (Disconnectable proxyServer = ninio.create(ProxyServer.defaultUnsecureServer(new Address(Address.ANY, proxyPort), null))) {
 				try (ProxyProvider proxyClient0 = ninio.create(ProxyClient.defaultUnsecureClient(new Address(Address.LOCALHOST, proxyPort)))) {
 					final Lock<Double, IOException> lock0 = new Lock<>();
-					try (PingConnecter client0 = PingTimeout.wrap(1d, ninio.create(PingClient.builder().with(proxyClient0.raw())))) {
+					try (PingConnecter client0 = PingTimeout.wrap(1d, ninio.create(PingClient.builder().with(proxyClient0.raw(DEFAULT_RECIPIENT_ID))))) {
 						client0.connect(new PingConnection() {
 							@Override
 							public void failed(IOException ioe) {
@@ -53,7 +55,7 @@ public class ProxyOpenLeaveOpenPingTest {
 						System.out.println(lock0.waitFor());
 						try (ProxyProvider proxyClient1 = ninio.create(ProxyClient.defaultUnsecureClient(new Address(Address.LOCALHOST, proxyPort)))) {
 							final Lock<Double, IOException> lock1 = new Lock<>();
-							try (PingConnecter client1 = PingTimeout.wrap(1d, ninio.create(PingClient.builder().with(proxyClient1.raw())))) {
+							try (PingConnecter client1 = PingTimeout.wrap(1d, ninio.create(PingClient.builder().with(proxyClient1.raw(DEFAULT_RECIPIENT_ID))))) {
 								client1.connect(new PingConnection() {
 									@Override
 									public void failed(IOException ioe) {

--- a/ninio-proxy/src/test/java/com/davfx/ninio/proxy/TestUtil.java
+++ b/ninio-proxy/src/test/java/com/davfx/ninio/proxy/TestUtil.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.ServerSocket;
 
 public final class TestUtil {
+    public static final String DEFAULT_RECIPIENT_ID = "1";
 
     public static int findAvailablePort() {
         try (ServerSocket s = new ServerSocket(0)) {


### PR DESCRIPTION
When a sinemapro-slave send a connect command (to a proxy or a gateway), it now includes the recipientId in the command header.
This allow the collect-gateway to properly route the packet from the collect-agent to the sinemapro-slave.
This field is ignored by proxy