### PR TITLE
fix: [LSPD-6285] Log socket buffer size

### DIFF
--- a/ninio-core/src/main/java/com/davfx/ninio/core/UdpSocket.java
+++ b/ninio-core/src/main/java/com/davfx/ninio/core/UdpSocket.java
@@ -2,7 +2,6 @@ package com.davfx.ninio.core;
 
 import com.davfx.ninio.core.dependencies.Dependencies;
 import com.davfx.ninio.core.supervision.metrics.DisplayableMetricsManager;
-import com.davfx.ninio.core.supervision.metrics.MetricsParams;
 import com.davfx.ninio.core.supervision.tracking.RequestTracker;
 import com.davfx.ninio.core.supervision.tracking.RequestTrackerManager;
 import com.davfx.ninio.util.ConfigUtils;
@@ -215,8 +214,14 @@ public final class UdpSocket implements Connecter {
                     if (SOCKET_READ_BUFFER_SIZE > 0L) {
                         channel.socket().setReceiveBufferSize((int) SOCKET_READ_BUFFER_SIZE);
                     }
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("Socket receive buffer size: {}", channel.socket().getReceiveBufferSize());
+                    }
                     if (SOCKET_WRITE_BUFFER_SIZE > 0L) {
                         channel.socket().setSendBufferSize((int) SOCKET_WRITE_BUFFER_SIZE);
+                    }
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("Socket send buffer size: {}", channel.socket().getSendBufferSize());
                     }
                     final SelectionKey selectionKey = queue.register(channel);
                     currentSelectionKey = selectionKey;


### PR DESCRIPTION
Logs socket's receive and send buffer sizes. This can be useful if we want to later adjust the parameter setting this value.
These buffer sizes are given has a hint to the network implementation. On linux, the receive buffer size should not exceed the `core.net.rmem_max` value (or else it seems to be set to that max value).